### PR TITLE
Context Menu

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -17,6 +17,7 @@
             <Image x:Key="LantekIcon" Source="pack://application:,,,/Resources/lantek.ico"></Image>
             <Image x:Key="Keywords" Source="pack://application:,,,/Resources/keywords.ico"></Image>
             <Image x:Key="MainIcon" Source="pack://application:,,,/Resources/Icon.ico"></Image>
+
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/LogFile.cs
+++ b/LogFile.cs
@@ -6,6 +6,8 @@ namespace STAT
     public class LogFile
     {
         public string FolderName { get; set; }
+        
+        public string FolderPath { get; set; }
 
         public string Name { get; set; }
 

--- a/LogViewer.xaml
+++ b/LogViewer.xaml
@@ -1,0 +1,14 @@
+﻿<Window x:Class="STAT.LogViewer"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:STAT"
+        mc:Ignorable="d"
+        Title="LogViewer" Height="768" Width="1024">
+
+    <Grid>
+        <ListBox x:Name="LogViewerListBox" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"/>
+
+    </Grid>
+</Window>

--- a/LogViewer.xaml.cs
+++ b/LogViewer.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace STAT
+{
+    /// <summary>
+    /// Interaction logic for LogViewer.xaml
+    /// </summary>
+    public partial class LogViewer : Window
+    {
+        private readonly SolidColorBrush bgColor = new SolidColorBrush();
+        public LogViewer()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -16,6 +16,11 @@
         <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.TabsGrid.Background">#414141</SolidColorBrush>
         <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonTabControl.Content.Background">#F1F1F1</SolidColorBrush>
         <SolidColorBrush x:Key="Fluent.Ribbon.Brushes.RibbonWindow.TitleBackground">#414141</SolidColorBrush>
+
+        <ContextMenu x:Key="LogFileContextMenu">
+            <MenuItem Header="Open File Location" Click="OpenFileLocationContext_Click"/>
+            <MenuItem Header="Open Log File" Click="OpenLogFileContext_Click"/>
+        </ContextMenu>
     </Fluent:RibbonWindow.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
@@ -78,34 +83,34 @@
         <Grid Grid.Row="1" Name="HomeGrid" >
             <TabControl Name="OverviewTabControl" Visibility="Visible">
                 <TabItem Header="Overview">
-                    <ListView HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Name="OverviewListView" Visibility="Hidden">
+                    <ListView HorizontalAlignment="Stretch" VerticalAlignment="Stretch" x:Name="OverviewListView" Visibility="Hidden">
                         <ListView.View>
-                            <GridView AllowsColumnReorder="False">
+                            <GridView AllowsColumnReorder="False" x:Name="GridView1">
                                 <GridViewColumn x:Name="BackupNameCol" Header="Backup Name" Width="Auto">
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
-                                            <TextBlock x:Name="BackupNameColTextBox" Text="{Binding FolderName}" Foreground="{Binding TextColor}" />
+                                            <TextBlock x:Name="BackupNameColTextBox" Text="{Binding FolderName}" Foreground="{Binding TextColor}" ContextMenu="{StaticResource LogFileContextMenu}"/>
                                         </DataTemplate>
                                     </GridViewColumn.CellTemplate>
                                 </GridViewColumn>
                                 <GridViewColumn x:Name="FilePathCol" Header="File Path" Width="Auto">
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
-                                            <TextBlock x:Name="FilePathColTextBox" Text="{Binding FilePath}" Foreground="{Binding TextColor}" />
+                                            <TextBlock x:Name="FilePathColTextBox" Text="{Binding FilePath}" Foreground="{Binding TextColor}" ContextMenu="{StaticResource LogFileContextMenu}"/>
                                         </DataTemplate>
                                     </GridViewColumn.CellTemplate>
                                 </GridViewColumn>
                                 <GridViewColumn x:Name="FileDateCol" Header="Date" Width="Auto">
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
-                                            <TextBlock x:Name="FileDateColTextBox" Text="{Binding FileDate}" Foreground="{Binding TextColor}" />
+                                            <TextBlock x:Name="FileDateColTextBox" Text="{Binding FileDate}" Foreground="{Binding TextColor}" ContextMenu="{StaticResource LogFileContextMenu}"/>
                                         </DataTemplate>
                                     </GridViewColumn.CellTemplate>
                                 </GridViewColumn>
                                 <GridViewColumn x:Name="ResultCol" Header="Result" Width="Auto">
                                     <GridViewColumn.CellTemplate>
                                         <DataTemplate>
-                                            <TextBlock x:Name="ResultColTextBox" Text="{Binding Result}" Foreground="{Binding TextColor}" />
+                                            <TextBlock x:Name="ResultColTextBox" Text="{Binding Result}" Foreground="{Binding TextColor}" ContextMenu="{StaticResource LogFileContextMenu}"/>
                                         </DataTemplate>
                                     </GridViewColumn.CellTemplate>
                                 </GridViewColumn>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using WK.Libraries.BetterFolderBrowserNS;
 using Microsoft.Win32;
 using System.Windows.Media;
 using System.Data;
+using System.Diagnostics;
 
 
 namespace STAT
@@ -116,7 +117,7 @@ namespace STAT
 
         #region Processing
         #region Home Tab
-        public List<string> GetBaseDirectories()
+        private List<string> GetBaseDirectories()
         {
             List<string> baseDirectories = new List<String>();
             BetterFolderBrowser baseDirectoryBrowser = new BetterFolderBrowser
@@ -136,7 +137,7 @@ namespace STAT
             return baseDirectories;
         }
 
-        public List<string> GetFileContent(string fileName)
+        private List<string> GetFileContent(string fileName)
         {
             List<string> fileContent = new List<string>();
 
@@ -151,7 +152,7 @@ namespace STAT
             return fileContent;
         }
 
-        public string AnalyzeFileContent(List<string> fileContent)
+        private string AnalyzeFileContent(List<string> fileContent)
         {
             string resultString = "Failure";
             for (int i = 0; i < NewKeywordList.Count; i++)
@@ -178,7 +179,7 @@ namespace STAT
             return fontColor;
         }
 
-        public void GenerateOverView()
+        private void GenerateOverView()
         {
             List<LogFile> items = new List<LogFile>();
             foreach (string directory in GetBaseDirectories())
@@ -190,11 +191,12 @@ namespace STAT
                     items.Add(new LogFile()
                     {
                         FolderName = new DirectoryInfo(directory).Name,
+                        FolderPath = new DirectoryInfo(directory).FullName,
                         FilePath = latestFile.ToString(),
                         FileDate = File.GetCreationTime(latestFile.ToString()),
                         Result = AnalyzeFileContent(GetFileContent(latestFile)),
                         TextColor = SetFontColor(latestFile)
-                    });
+                    }); ;
                 }
                 catch
                 {
@@ -205,7 +207,7 @@ namespace STAT
             OverviewListView.Visibility = Visibility;
         }
 
-        public Boolean QueryPartSearch(string Company)
+        private Boolean QueryPartSearch(string Company)
         {
 
             String url = "";
@@ -345,6 +347,30 @@ namespace STAT
                 MessageBox.Show(ex.Message);
             }
         }
+
+
+        private void OpenFileLocationContext_Click(object sender, RoutedEventArgs e)
+        {
+            LogFile SelectedLogFile = (LogFile)OverviewListView.SelectedItem;
+            Process.Start("explorer.exe", "/select, \"" + SelectedLogFile.FilePath + "\"");
+        }
+
+        private void OpenLogFileContext_Click(object sender, RoutedEventArgs e)
+        {
+            LogViewer logViewer = new LogViewer();
+            LogFile SelectedLogFile = (LogFile)OverviewListView.SelectedItem;
+            foreach (string line in GetFileContent(SelectedLogFile.FilePath))
+            {
+                if(line != "")
+                {
+                    logViewer.LogViewerListBox.Items.Add(line);
+                }
+            }
+
+            logViewer.ShowDialog();
+        }
+
+
         #endregion
 
         #region Options Tab

--- a/STAT.csproj
+++ b/STAT.csproj
@@ -89,6 +89,10 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Icons.resx</DependentUpon>
     </Compile>
+    <Page Include="LogViewer.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
@@ -98,6 +102,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="LogFile.cs" />
+    <Compile Include="LogViewer.xaml.cs">
+      <DependentUpon>LogViewer.xaml</DependentUpon>
+    </Compile>
     <Compile Include="MainWindow.xaml.cs">
       <DependentUpon>MainWindow.xaml</DependentUpon>
       <SubType>Code</SubType>


### PR DESCRIPTION
Added a context menu with two options.
1) Open File Location - Runs explorer.exe in the directory of the selected log file and passes in arguments to make the log file the selected item in the Explorer window.

2) Open Log File - Created a LogViewer class with a simple window and a listbox. When the menu item is clicked it creates an instance of the class, parses the logfile into each line of the listbox then displays on screen.

Resolves #5.